### PR TITLE
Fix random generator issues

### DIFF
--- a/jobs/cassandra/templates/bin/nodetool
+++ b/jobs/cassandra/templates/bin/nodetool
@@ -8,5 +8,6 @@ export LANG=en_US.UTF-8
 export CASSANDRA_CONF=/var/vcap/jobs/cassandra/conf
 export JAVA_HOME=/var/vcap/packages/openjdk
 export JVM_OPTS=-Djava.io.tmpdir=/var/vcap/data/cassandra/jna-tmp
+export JVM_OPTS="${JVM_OPTS} -Djava.security.egd=file:/dev/./urandom"
 
 exec chpst -u vcap:vcap env HOME=/home/vcap /var/vcap/packages/cassandra/bin/nodetool "$@"

--- a/jobs/cassandra/templates/bin/sstableloader
+++ b/jobs/cassandra/templates/bin/sstableloader
@@ -8,5 +8,6 @@ export LANG=en_US.UTF-8
 export CASSANDRA_CONF=/var/vcap/jobs/cassandra/conf
 export JAVA_HOME=/var/vcap/packages/openjdk
 export JVM_OPTS=-Djava.io.tmpdir=/var/vcap/data/cassandra/jna-tmp
+export JVM_OPTS="${JVM_OPTS} -Djava.security.egd=file:/dev/./urandom"
 
 exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/sstableloader "$@"

--- a/jobs/cassandra/templates/config/jvm.options.erb
+++ b/jobs/cassandra/templates/config/jvm.options.erb
@@ -139,6 +139,10 @@
 # comment out this entry to enable IPv6 support).
 -Djava.net.preferIPv4Stack=true
 
+# Use /dev/urandom instead of /dev/random to avoid blocking when random pool
+# is exhausted.
+-Djava.security.egd=file:/dev/./urandom
+
 ### Debug options
 
 # uncomment to enable flight recorder


### PR DESCRIPTION
Use /dev/urandom as the random number generator, in order to avoid blocking when generating UUIDs